### PR TITLE
レシート一覧ページにPaginationを追加 

### DIFF
--- a/src/components/atoms/DropDownMenu.vue
+++ b/src/components/atoms/DropDownMenu.vue
@@ -1,0 +1,32 @@
+<template>
+  <label for="order-select">{{ label }}</label>
+  <select
+    id="order-select"
+    name="receipt-display-order"
+    class="ml-2 rounded border border-gray-400 p-1"
+    @change="changeOption"
+  >
+    <option
+      v-for="(optionLabel, optionIndex) in options"
+      :key="optionIndex"
+      :value="optionLabel.toLowerCase()"
+    >
+      {{ optionLabel }}
+    </option>
+  </select>
+</template>
+<script lang="ts" setup>
+defineProps<{
+  label: string
+  options: string[]
+}>()
+const emit = defineEmits<{
+  'update-selected-option': [string]
+}>()
+
+const changeOption = (event: Event) => {
+  console.log('perry: changeOption: changeOption: ', event)
+  const selectElement = event.target as HTMLSelectElement
+  emit('update-selected-option', selectElement.value)
+}
+</script>

--- a/src/components/atoms/DropDownMenu.vue
+++ b/src/components/atoms/DropDownMenu.vue
@@ -27,7 +27,6 @@ const emit = defineEmits<{
 }>()
 
 const changeOption = (event: Event) => {
-  console.log('perry: changeOption: changeOption: ', event)
   const selectElement = event.target as HTMLSelectElement
   emit('update-selected-option', selectElement.value as ReceiptDisplayOrder)
 }

--- a/src/components/atoms/DropDownMenu.vue
+++ b/src/components/atoms/DropDownMenu.vue
@@ -16,17 +16,19 @@
   </select>
 </template>
 <script lang="ts" setup>
+import type { ReceiptDisplayOrder } from '@/types/receipt'
+
 defineProps<{
   label: string
   options: string[]
 }>()
 const emit = defineEmits<{
-  'update-selected-option': [string]
+  'update-selected-option': [ReceiptDisplayOrder]
 }>()
 
 const changeOption = (event: Event) => {
   console.log('perry: changeOption: changeOption: ', event)
   const selectElement = event.target as HTMLSelectElement
-  emit('update-selected-option', selectElement.value)
+  emit('update-selected-option', selectElement.value as ReceiptDisplayOrder)
 }
 </script>

--- a/src/components/atoms/ItemTable.vue
+++ b/src/components/atoms/ItemTable.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import type { BoughtItem } from '@/interfaces/receipt'
+import type { BoughtItem } from '@/types/receipt'
 
 defineProps<{ boughtItems?: BoughtItem[] }>()
 </script>

--- a/src/components/atoms/LoadingIcon.vue
+++ b/src/components/atoms/LoadingIcon.vue
@@ -1,26 +1,24 @@
 <template>
-  <div class="fixed left-0 top-0 flex h-full w-full justify-center bg-white">
-    <svg
-      width="100px"
-      fill="#0D9488FF"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
+  <svg
+    width="100px"
+    fill="#0D9488FF"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12,1A11,11,0,1,0,23,12,11,11,0,0,0,12,1Zm0,19a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+      opacity=".25"
+    />
+    <path
+      d="M12,4a8,8,0,0,1,7.89,6.7A1.53,1.53,0,0,0,21.38,12h0a1.5,1.5,0,0,0,1.48-1.75,11,11,0,0,0-21.72,0A1.5,1.5,0,0,0,2.62,12h0a1.53,1.53,0,0,0,1.49-1.3A8,8,0,0,1,12,4Z"
     >
-      <path
-        d="M12,1A11,11,0,1,0,23,12,11,11,0,0,0,12,1Zm0,19a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
-        opacity=".25"
+      <animateTransform
+        attributeName="transform"
+        type="rotate"
+        dur="0.75s"
+        values="0 12 12;360 12 12"
+        repeatCount="indefinite"
       />
-      <path
-        d="M12,4a8,8,0,0,1,7.89,6.7A1.53,1.53,0,0,0,21.38,12h0a1.5,1.5,0,0,0,1.48-1.75,11,11,0,0,0-21.72,0A1.5,1.5,0,0,0,2.62,12h0a1.53,1.53,0,0,0,1.49-1.3A8,8,0,0,1,12,4Z"
-      >
-        <animateTransform
-          attributeName="transform"
-          type="rotate"
-          dur="0.75s"
-          values="0 12 12;360 12 12"
-          repeatCount="indefinite"
-        />
-      </path>
-    </svg>
-  </div>
+    </path>
+  </svg>
 </template>

--- a/src/components/atoms/PageTitle.vue
+++ b/src/components/atoms/PageTitle.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import type { BoughtItem } from '@/interfaces/receipt'
+import type { BoughtItem } from '@/types/receipt'
 
 defineProps<{ boughtItems?: BoughtItem[] }>()
 </script>

--- a/src/components/molecules/LoadingFullScreen.vue
+++ b/src/components/molecules/LoadingFullScreen.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="fixed left-0 top-0 flex h-full w-full justify-center bg-white">
+    <LoadingIcon />
+  </div>
+</template>
+<script setup lang="ts">
+import LoadingIcon from '@/components/atoms/LoadingIcon.vue'
+</script>

--- a/src/components/molecules/OrderSelectBox.vue
+++ b/src/components/molecules/OrderSelectBox.vue
@@ -4,8 +4,8 @@
   >
     <p>
       {{ receiptCount }}件{{
-        minCountTodo && maxCountTodo
-          ? `中 ${minCountTodo}-${maxCountTodo}件`
+        minDisplayCount && maxDisplayCount
+          ? `中 ${minDisplayCount}-${maxDisplayCount}件`
           : ''
       }}
     </p>
@@ -24,8 +24,8 @@ import DropDownMenu from '@/components/atoms/DropDownMenu.vue'
 
 defineProps<{
   receiptCount: number
-  minCountTodo?: number
-  maxCountTodo?: number
+  minDisplayCount?: number
+  maxDisplayCount?: number
 }>()
 const emit = defineEmits<{
   'order-changed': [ReceiptDisplayOrder]

--- a/src/components/molecules/OrderSelectBox.vue
+++ b/src/components/molecules/OrderSelectBox.vue
@@ -1,0 +1,34 @@
+<template>
+  <div
+    class="flex items-center justify-between border-b border-t border-gray-400 px-1 py-2"
+  >
+    <p>{{ receiptCount }}件</p>
+    <div>
+      <label for="order-select">Sort by:</label>
+      <select
+        id="order-select"
+        name="receipt-display-order"
+        class="ml-2 rounded border border-gray-400 p-1"
+        @change="changeReceiptOrder"
+      >
+        <option value="newest">Newest</option>
+        <option value="oldest">Oldest</option>
+      </select>
+    </div>
+  </div>
+</template>
+<script lang="ts" setup>
+import type { ReceiptDisplayOrder } from '@/types/receipt'
+
+defineProps<{
+  receiptCount: number
+}>()
+const emit = defineEmits<{
+  'order-changed': [ReceiptDisplayOrder]
+}>()
+
+const changeReceiptOrder = (event: Event) => {
+  const selectElement = event.target as HTMLSelectElement
+  emit('order-changed', selectElement.value as ReceiptDisplayOrder)
+}
+</script>

--- a/src/components/molecules/OrderSelectBox.vue
+++ b/src/components/molecules/OrderSelectBox.vue
@@ -32,7 +32,6 @@ const emit = defineEmits<{
 }>()
 
 const changeReceiptOrder = (updatedOption: ReceiptDisplayOrder) => {
-  console.log('perry: changeReceiptOrder: updatedOption: ', updatedOption)
   emit('order-changed', updatedOption)
 }
 </script>

--- a/src/components/molecules/OrderSelectBox.vue
+++ b/src/components/molecules/OrderSelectBox.vue
@@ -4,21 +4,17 @@
   >
     <p>{{ receiptCount }}件</p>
     <div>
-      <label for="order-select">Sort by:</label>
-      <select
-        id="order-select"
-        name="receipt-display-order"
-        class="ml-2 rounded border border-gray-400 p-1"
-        @change="changeReceiptOrder"
-      >
-        <option value="newest">Newest</option>
-        <option value="oldest">Oldest</option>
-      </select>
+      <DropDownMenu
+        :label="'Sort by:'"
+        :options="['Newest', 'Oldest']"
+        @update-selected-option="changeReceiptOrder"
+      />
     </div>
   </div>
 </template>
 <script lang="ts" setup>
 import type { ReceiptDisplayOrder } from '@/types/receipt'
+import DropDownMenu from '@/components/atoms/DropDownMenu.vue'
 
 defineProps<{
   receiptCount: number
@@ -27,8 +23,8 @@ const emit = defineEmits<{
   'order-changed': [ReceiptDisplayOrder]
 }>()
 
-const changeReceiptOrder = (event: Event) => {
-  const selectElement = event.target as HTMLSelectElement
-  emit('order-changed', selectElement.value as ReceiptDisplayOrder)
+const changeReceiptOrder = (updatedOption: ReceiptDisplayOrder) => {
+  console.log('perry: changeReceiptOrder: updatedOption: ', updatedOption)
+  emit('order-changed', updatedOption)
 }
 </script>

--- a/src/components/molecules/OrderSelectBox.vue
+++ b/src/components/molecules/OrderSelectBox.vue
@@ -2,7 +2,13 @@
   <div
     class="flex items-center justify-between border-b border-t border-gray-400 px-1 py-2"
   >
-    <p>{{ receiptCount }}件</p>
+    <p>
+      {{ receiptCount }}件{{
+        minCountTodo && maxCountTodo
+          ? `中 ${minCountTodo}-${maxCountTodo}件`
+          : ''
+      }}
+    </p>
     <div>
       <DropDownMenu
         :label="'Sort by:'"
@@ -18,6 +24,8 @@ import DropDownMenu from '@/components/atoms/DropDownMenu.vue'
 
 defineProps<{
   receiptCount: number
+  minCountTodo?: number
+  maxCountTodo?: number
 }>()
 const emit = defineEmits<{
   'order-changed': [ReceiptDisplayOrder]

--- a/src/components/organisms/ReceiptOrganizer.vue
+++ b/src/components/organisms/ReceiptOrganizer.vue
@@ -165,7 +165,7 @@ import type {
   ItemInfo,
   MoveToStepThreePayload,
   ReceiptInfo
-} from '@/interfaces/receipt'
+} from '@/types/receipt'
 import ErrorMessage from '@/components/atoms/ErrorMessage.vue'
 import LoadingIcon from '@/components/atoms/LoadingIcon.vue'
 import BaseButton from '@/components/atoms/BaseButton.vue'

--- a/src/components/organisms/ReceiptOrganizer.vue
+++ b/src/components/organisms/ReceiptOrganizer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <LoadingIcon v-if="isLoading" />
+    <LoadingFullScreen v-if="isLoading" />
     <template v-else>
       <ErrorMessage v-if="errorMessage">
         {{ errorMessage }}
@@ -167,8 +167,8 @@ import type {
   ReceiptInfo
 } from '@/types/receipt'
 import ErrorMessage from '@/components/atoms/ErrorMessage.vue'
-import LoadingIcon from '@/components/atoms/LoadingIcon.vue'
 import BaseButton from '@/components/atoms/BaseButton.vue'
+import LoadingFullScreen from '@/components/molecules/LoadingFullScreen.vue'
 
 const { receiptTotal, receiptInfo, selectedFile, receiptTitle, userWhoPaid } =
   defineProps<{

--- a/src/components/organisms/SavePreparation.vue
+++ b/src/components/organisms/SavePreparation.vue
@@ -1,5 +1,5 @@
 <template>
-  <LoadingIcon v-if="isLoading" />
+  <LoadingFullScreen v-if="isLoading" />
   <template v-else>
     <div class="mt-5">
       <ErrorMessage v-if="errorMessage || analyzeReceiptError">
@@ -88,8 +88,8 @@
 <script setup lang="ts">
 import type { MoveToStepTwoPayload } from '@/types/receipt'
 import ErrorMessage from '@/components/atoms/ErrorMessage.vue'
-import LoadingIcon from '@/components/atoms/LoadingIcon.vue'
 import BaseButton from '@/components/atoms/BaseButton.vue'
+import LoadingFullScreen from '@/components/molecules/LoadingFullScreen.vue'
 
 defineProps<{
   userWhoPaid: string

--- a/src/components/organisms/SavePreparation.vue
+++ b/src/components/organisms/SavePreparation.vue
@@ -86,7 +86,7 @@
   </template>
 </template>
 <script setup lang="ts">
-import type { MoveToStepTwoPayload } from '@/interfaces/receipt'
+import type { MoveToStepTwoPayload } from '@/types/receipt'
 import ErrorMessage from '@/components/atoms/ErrorMessage.vue'
 import LoadingIcon from '@/components/atoms/LoadingIcon.vue'
 import BaseButton from '@/components/atoms/BaseButton.vue'

--- a/src/composables/useAnalyzeReceipt.ts
+++ b/src/composables/useAnalyzeReceipt.ts
@@ -1,4 +1,4 @@
-import type { AnalyzeReceiptResponse } from '@/interfaces/receipt'
+import type { AnalyzeReceiptResponse } from '@/types/receipt'
 import { ref } from 'vue'
 
 export const useAnalyzeReceipt = () => {

--- a/src/composables/useGetReceiptInfo.ts
+++ b/src/composables/useGetReceiptInfo.ts
@@ -1,4 +1,4 @@
-import type { ReceiptDetailsInfoResponse } from '@/interfaces/receipt'
+import type { ReceiptDetailsInfoResponse } from '@/types/receipt'
 import { ref } from 'vue'
 
 export const useGetReceiptInfo = () => {

--- a/src/composables/useGetReceiptListInfo.ts
+++ b/src/composables/useGetReceiptListInfo.ts
@@ -34,7 +34,10 @@ export const useGetReceiptList = () => {
     pageNumber: number,
     sortOrder: ReceiptDisplayOrder
   ) => {
-    console.log('perry: function getReceiptData')
+    console.log('perry: function getReceiptData: ', {
+      pageNumber,
+      sortOrder
+    })
     isLoading.value = true
     // TODO: dev tools error: useGetReceiptListInfo.ts:39 [nuxt] [useAsyncData] Component is already mounted, please use $fetch instead. See
     const { data: receiptListData, error: fetchError } = await useAsyncData(
@@ -43,7 +46,7 @@ export const useGetReceiptList = () => {
         $fetch<ReceiptListInfoResponse>('/api/receipt-info', {
           method: 'GET',
           params: {
-            pages: pageNumber,
+            page: pageNumber,
             sort_by: getSortByOrderParam(sortOrder)
           },
           headers: { 'Content-Type': 'application/json' }

--- a/src/composables/useGetReceiptListInfo.ts
+++ b/src/composables/useGetReceiptListInfo.ts
@@ -1,21 +1,49 @@
-import type { ReceiptListInfoResponse } from '@/types/receipt'
+import { RECEIPT_ORDER } from '@/constants'
+import type {
+  ReceiptListInfoResponse,
+  ReceiptDisplayOrder
+} from '@/types/receipt'
 import { ref } from 'vue'
+
+const SORT_TYPE = {
+  ASCENDING: 'asc',
+  DESCENDING: 'desc'
+} as const
 
 export const useGetReceiptList = () => {
   const data = ref<ReceiptListInfoResponse | null>(null)
   const error = ref<string | null>(null)
   const isLoading = ref<boolean>(false)
 
-  const getReceiptListData = async (pageNumber: number) => {
+  const getSortByOrderParam = (sortOrder: ReceiptDisplayOrder) => {
+    console.log('perry: sortOrder: getSortByOrderParam: ', sortOrder)
+    switch (sortOrder) {
+      case RECEIPT_ORDER.NEWEST:
+        console.log('perry: getSortByOrderParam: case RECEIPT_ORDER.NEWEST:')
+        return SORT_TYPE.DESCENDING
+      case RECEIPT_ORDER.OLDEST:
+        console.log('perry: getSortByOrderParam: case RECEIPT_ORDER.OLDEST:')
+        return SORT_TYPE.ASCENDING
+      default:
+        console.log('perry: getSortByOrderParam: default:')
+        return SORT_TYPE.DESCENDING
+    }
+  }
+
+  const getReceiptListData = async (
+    pageNumber: number,
+    sortOrder: ReceiptDisplayOrder
+  ) => {
     console.log('perry: function getReceiptData')
     isLoading.value = true
     const { data: receiptListData, error: fetchError } = await useAsyncData(
-      `receipt-list-${pageNumber}`,
+      `receipt-list-${pageNumber}-${sortOrder}`,
       () =>
         $fetch<ReceiptListInfoResponse>('/api/receipt-info', {
           method: 'GET',
           params: {
-            pages: pageNumber
+            pages: pageNumber,
+            sort_by: getSortByOrderParam(sortOrder)
           },
           headers: { 'Content-Type': 'application/json' }
         })

--- a/src/composables/useGetReceiptListInfo.ts
+++ b/src/composables/useGetReceiptListInfo.ts
@@ -16,16 +16,12 @@ export const useGetReceiptList = () => {
   const isLoading = ref<boolean>(false)
 
   const getSortByOrderParam = (sortOrder: ReceiptDisplayOrder) => {
-    console.log('perry: sortOrder: getSortByOrderParam: ', sortOrder)
     switch (sortOrder) {
       case RECEIPT_ORDER.NEWEST:
-        console.log('perry: getSortByOrderParam: case RECEIPT_ORDER.NEWEST:')
         return SORT_TYPE.DESCENDING
       case RECEIPT_ORDER.OLDEST:
-        console.log('perry: getSortByOrderParam: case RECEIPT_ORDER.OLDEST:')
         return SORT_TYPE.ASCENDING
       default:
-        console.log('perry: getSortByOrderParam: default:')
         return SORT_TYPE.DESCENDING
     }
   }
@@ -34,10 +30,6 @@ export const useGetReceiptList = () => {
     pageNumber: number,
     sortOrder: ReceiptDisplayOrder
   ) => {
-    console.log('perry: function getReceiptData: ', {
-      pageNumber,
-      sortOrder
-    })
     isLoading.value = true
     // TODO: dev tools error: useGetReceiptListInfo.ts:39 [nuxt] [useAsyncData] Component is already mounted, please use $fetch instead. See
     const { data: receiptListData, error: fetchError } = await useAsyncData(

--- a/src/composables/useGetReceiptListInfo.ts
+++ b/src/composables/useGetReceiptListInfo.ts
@@ -36,6 +36,7 @@ export const useGetReceiptList = () => {
   ) => {
     console.log('perry: function getReceiptData')
     isLoading.value = true
+    // TODO: dev tools error: useGetReceiptListInfo.ts:39 [nuxt] [useAsyncData] Component is already mounted, please use $fetch instead. See
     const { data: receiptListData, error: fetchError } = await useAsyncData(
       `receipt-list-${pageNumber}-${sortOrder}`,
       () =>

--- a/src/composables/useGetReceiptListInfo.ts
+++ b/src/composables/useGetReceiptListInfo.ts
@@ -1,4 +1,4 @@
-import type { ReceiptListInfoResponse } from '@/interfaces/receipt'
+import type { ReceiptListInfoResponse } from '@/types/receipt'
 import { ref } from 'vue'
 
 export const useGetReceiptList = () => {

--- a/src/composables/useSaveReceiptInfo.ts
+++ b/src/composables/useSaveReceiptInfo.ts
@@ -1,4 +1,4 @@
-import type { ItemInfo, ReceiptDetailsInfoResponse } from '@/interfaces/receipt'
+import type { ItemInfo, ReceiptDetailsInfoResponse } from '@/types/receipt'
 import { ref } from 'vue'
 
 export const useSaveReceiptInfo = () => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,3 +12,7 @@ export const USERS = {
     NAME: 'both'
   }
 } as const
+export const RECEIPT_ORDER = {
+  NEWEST: 'newest',
+  OLDEST: 'oldest'
+} as const

--- a/src/e2e/tests/save-receipt.spec.ts
+++ b/src/e2e/tests/save-receipt.spec.ts
@@ -198,7 +198,7 @@ test('Adding Receipt. Check receipt details after adding. Check Receipt List for
   await expect(page.getByRole('heading', { name: 'Test Title' })).toBeVisible()
   await expect(page.getByText('Perry: 3,113円')).toBeVisible()
   await expect(page.getByText('Hannah: 2,553円')).toBeVisible()
-  await page.getByRole('link', { name: '見る' }).nth(3).click()
+  await page.getByRole('link', { name: '見る' }).nth(0).click()
   await expect(
     page.getByRole('heading', { name: 'Test Title 2982580523' })
   ).toBeVisible()

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -1,13 +1,11 @@
-<!-- TODO: 
- - At some point, and a design system guide, which will display the color-codes used for the project
- - Add pagination to url /receipts/page=3
--->
 <template>
   <div>
     <PageTitle>Receipt List</PageTitle>
     <div>
       <OrderSelectBox
         :receipt-count="receiptInfo?.receipt_count || 0"
+        :min-count-todo="minCountTodo"
+        :max-count-todo="maxCountTodo"
         class="mt-5"
         @order-changed="orderChangedTodo"
       />
@@ -54,7 +52,7 @@
         </button>
         <div class="flex">
           <button
-            v-for="pageNumber in MAX_PAGE_TODO"
+            v-for="pageNumber in lastPage"
             :key="pageNumber"
             class="mr-1 flex h-11 w-11 items-center justify-center rounded-full bg-gray-400 text-white last:mr-0 hover:opacity-80"
             :class="{ 'bg-teal-600': pageNumber === currentPage }"
@@ -88,51 +86,81 @@ import type {
 definePageMeta({
   layout: 'common-layout'
 })
-// const
+const route = useRoute()
+// constants
 const FIRST_PAGE = 1 as const
-// TODO: APIより取得するべきなので修正必須
-const MAX_PAGE_TODO = 5
+const MAX_RECEIPT_LIST_ITEMS_PER_PAGE = 10 as const
+const OFFSET_FOR_MIN_COUNT_TODO = 9
 // state
 const receiptInfo = ref<ReceiptListInfoResponse | null>()
-const currentPage = ref<number>(FIRST_PAGE)
-// TODO: 対応必須
+const currentPage = ref<number>(
+  route.query.page ? Number(route.query.page as string) : FIRST_PAGE
+)
+const lastPage = ref<number>()
 const isLoading = ref(false)
 const sortOrder = ref<ReceiptDisplayOrder>(RECEIPT_ORDER.NEWEST)
 // composables
 useHead({
   title: 'Receipt List'
 })
-const route = useRoute()
 const { getReceiptListData } = useGetReceiptList()
 const { data: receiptPaginationInfo } = await getReceiptListData(
   currentPage.value,
   sortOrder.value
 )
 receiptInfo.value = receiptPaginationInfo
+lastPage.value = receiptPaginationInfo?.page_count
 // computed
 const isOnFirstPage = computed(() => currentPage.value === FIRST_PAGE)
 const isOnLastPage = computed(
   () => currentPage.value === receiptInfo.value?.page_count
 )
+const minCountTodo = computed(
+  () =>
+    currentPage.value * MAX_RECEIPT_LIST_ITEMS_PER_PAGE -
+    OFFSET_FOR_MIN_COUNT_TODO
+)
+const maxCountTodo = computed(() =>
+  isOnLastPage.value
+    ? receiptInfo.value?.receipt_count
+    : currentPage.value * MAX_RECEIPT_LIST_ITEMS_PER_PAGE
+)
 // methods
-const orderChangedTodo = async (receiptDisplayOrder: string) => {
+const orderChangedTodo = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
+  console.log(
+    'perry: orderChangedTodo: receiptDisplayOrder: ',
+    receiptDisplayOrder
+  )
   const { data: receiptPaginationInfo } = await getReceiptListData(
-    currentPage.value,
+    FIRST_PAGE,
     receiptDisplayOrder as ReceiptDisplayOrder
   )
-  console.log('perry: receiptInfo.value: ', receiptInfo.value)
   receiptInfo.value = receiptPaginationInfo
+  sortOrder.value = receiptDisplayOrder
+  currentPage.value = FIRST_PAGE
 }
-const changePage = (clickedPageNumber: number) => {
-  console.log('perry: changePage: clickedPageNumber: ', clickedPageNumber)
+const changePage = async (clickedPageNumber: number) => {
   isLoading.value = true
-}
-// lifecycle
-onMounted(() => {
-  console.log('perry: params: ', route.query)
-  if (route.query.page) {
-    // Set the state from the URL parameter
-    currentPage.value = Number(route.query.page as string)
+  try {
+    // TODO: Double check how navigateTo works
+    await navigateTo({
+      path: route.path,
+      query: {
+        ...route.query,
+        page: clickedPageNumber
+      }
+    })
+    const { data: receiptPaginationInfo } = await getReceiptListData(
+      clickedPageNumber,
+      sortOrder.value
+    )
+    currentPage.value = clickedPageNumber
+    receiptInfo.value = receiptPaginationInfo
+  } catch (error) {
+    // TODO: エラーパターン追加必須
+    console.log('perry: error: ', error)
+  } finally {
+    isLoading.value = false
   }
-})
+}
 </script>

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -1,38 +1,75 @@
+<!-- TODO: 
+ - At some point, and a design system guide, which will display the color-codes used for the project
+ - Add pagination to url /receipts/page=3
+-->
 <template>
   <div>
     <PageTitle>Receipt List</PageTitle>
-    <!-- TODO: 対応必須 -->
-    <!-- <LoadingIcon v-if="isLoading" /> -->
     <div>
       <OrderSelectBox
         :receipt-count="receiptInfo?.receipt_count || 0"
         class="mt-5"
         @order-changed="orderChangedTodo"
       />
-      <div
-        v-for="(receipt, receiptInfoKey) in receiptInfo?.receipt_data"
-        :key="receiptInfoKey"
-        class="mt-5 border-gray-400 pt-5 first:mt-0 [&:not(:first-child)]:border-t"
-      >
-        <h2 class="text-xl font-bold">{{ receipt.title }}</h2>
-        <p class="text-sm">
-          <span class="font-bold">Perry: </span>
-          {{ formatPrice(receipt.person_1_amount) }}
-        </p>
-        <p class="text-sm">
-          <span class="font-bold">Hannah: </span>
-          {{ formatPrice(receipt.person_2_amount) }}
-        </p>
-        <p class="text-sm">
-          <span class="font-bold">Date Posted: </span>
-          {{ formatDate(receipt.created_at) }}
-        </p>
-        <BaseButton
-          :to="`/receipts/${receipt.receipt_id}`"
-          class="mt-4 px-5 py-2 first:mt-0"
+      <div v-if="isLoading" class="mt-5 flex items-center justify-center">
+        <LoadingIcon />
+      </div>
+      <template v-else>
+        <div
+          v-for="(receipt, receiptInfoKey) in receiptInfo?.receipt_data"
+          :key="receiptInfoKey"
+          class="mt-5 border-gray-400 pt-5 first:mt-0 [&:not(:first-child)]:border-t"
         >
-          見る
-        </BaseButton>
+          <h2 class="text-xl font-bold">{{ receipt.title }}</h2>
+          <p class="text-sm">
+            <span class="font-bold">Perry: </span>
+            {{ formatPrice(receipt.person_1_amount) }}
+          </p>
+          <p class="text-sm">
+            <span class="font-bold">Hannah: </span>
+            {{ formatPrice(receipt.person_2_amount) }}
+          </p>
+          <p class="text-sm">
+            <span class="font-bold">Date Posted: </span>
+            {{ formatDate(receipt.created_at) }}
+          </p>
+          <BaseButton
+            :to="`/receipts/${receipt.receipt_id}`"
+            class="mt-4 px-5 py-2 first:mt-0"
+          >
+            見る
+          </BaseButton>
+        </div>
+      </template>
+      <!-- TODO: コンポーネント化する必要ある -->
+      <div
+        class="mt-5 flex items-center justify-between border-t border-gray-400 pt-4"
+      >
+        <button
+          class="font-bold disabled:opacity-50"
+          :disabled="isOnFirstPage"
+          @click="changePage(currentPage - 1)"
+        >
+          前
+        </button>
+        <div class="flex">
+          <button
+            v-for="pageNumber in MAX_PAGE_TODO"
+            :key="pageNumber"
+            class="mr-1 flex h-11 w-11 items-center justify-center rounded-full bg-gray-400 text-white last:mr-0 hover:opacity-80"
+            :class="{ 'bg-teal-600': pageNumber === currentPage }"
+            @click="() => changePage(pageNumber)"
+          >
+            {{ pageNumber }}
+          </button>
+        </div>
+        <button
+          class="font-bold disabled:opacity-50"
+          :disabled="isOnLastPage"
+          @click="changePage(currentPage + 1)"
+        >
+          次
+        </button>
       </div>
     </div>
   </div>
@@ -41,6 +78,7 @@
 import BaseButton from '@/components/atoms/BaseButton.vue'
 import PageTitle from '@/components/atoms/PageTitle.vue'
 import OrderSelectBox from '@/components/molecules/OrderSelectBox.vue'
+import LoadingIcon from '@/components/atoms/LoadingIcon.vue'
 import { RECEIPT_ORDER } from '@/constants'
 import type {
   ReceiptListInfoResponse,
@@ -50,21 +88,32 @@ import type {
 definePageMeta({
   layout: 'common-layout'
 })
-// consts
+// const
 const FIRST_PAGE = 1 as const
+// TODO: APIより取得するべきなので修正必須
+const MAX_PAGE_TODO = 5
 // state
 const receiptInfo = ref<ReceiptListInfoResponse | null>()
-const currentPage = ref(FIRST_PAGE)
+const currentPage = ref<number>(FIRST_PAGE)
 // TODO: 対応必須
-// const isLoading = ref(false)
+const isLoading = ref(false)
 const sortOrder = ref<ReceiptDisplayOrder>(RECEIPT_ORDER.NEWEST)
 // composables
+useHead({
+  title: 'Receipt List'
+})
+const route = useRoute()
 const { getReceiptListData } = useGetReceiptList()
 const { data: receiptPaginationInfo } = await getReceiptListData(
   currentPage.value,
   sortOrder.value
 )
 receiptInfo.value = receiptPaginationInfo
+// computed
+const isOnFirstPage = computed(() => currentPage.value === FIRST_PAGE)
+const isOnLastPage = computed(
+  () => currentPage.value === receiptInfo.value?.page_count
+)
 // methods
 const orderChangedTodo = async (receiptDisplayOrder: string) => {
   const { data: receiptPaginationInfo } = await getReceiptListData(
@@ -74,7 +123,16 @@ const orderChangedTodo = async (receiptDisplayOrder: string) => {
   console.log('perry: receiptInfo.value: ', receiptInfo.value)
   receiptInfo.value = receiptPaginationInfo
 }
-useHead({
-  title: 'Receipt List'
+const changePage = (clickedPageNumber: number) => {
+  console.log('perry: changePage: clickedPageNumber: ', clickedPageNumber)
+  isLoading.value = true
+}
+// lifecycle
+onMounted(() => {
+  console.log('perry: params: ', route.query)
+  if (route.query.page) {
+    // Set the state from the URL parameter
+    currentPage.value = Number(route.query.page as string)
+  }
 })
 </script>

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -125,20 +125,28 @@ const maxDisplayCount = computed(() =>
 )
 // methods
 const changeListOrder = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
-  const { data: receiptPaginationInfo } = await getReceiptListData(
-    FIRST_PAGE,
-    receiptDisplayOrder as ReceiptDisplayOrder
-  )
-  receiptInfo.value = receiptPaginationInfo
-  sortOrder.value = receiptDisplayOrder
-  currentPage.value = FIRST_PAGE
-  await navigateTo({
-    path: route.path,
-    query: {
-      ...route.query,
-      page: FIRST_PAGE
-    }
-  })
+  isLoading.value = true
+  try {
+    const { data: receiptPaginationInfo } = await getReceiptListData(
+      FIRST_PAGE,
+      receiptDisplayOrder as ReceiptDisplayOrder
+    )
+    receiptInfo.value = receiptPaginationInfo
+    sortOrder.value = receiptDisplayOrder
+    currentPage.value = FIRST_PAGE
+    await navigateTo({
+      path: route.path,
+      query: {
+        ...route.query,
+        page: FIRST_PAGE
+      }
+    })
+  } catch (error) {
+    // TODO: エラーパターン追加必須
+    console.error(error)
+  } finally {
+    isLoading.value = false
+  }
 }
 const changePage = async (clickedPageNumber: number) => {
   isLoading.value = true

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -1,10 +1,16 @@
 <template>
   <div>
     <PageTitle>Receipt List</PageTitle>
-    <LoadingIcon v-if="isLoading" />
+    <!-- TODO: 対応必須 -->
+    <!-- <LoadingIcon v-if="isLoading" /> -->
     <div>
+      <OrderSelectBox
+        :receipt-count="receiptInfo?.receipt_count || 0"
+        class="mt-5"
+        @order-changed="orderChangedTodo"
+      />
       <div
-        v-for="(receipt, receiptInfoKey) in receiptPaginationInfo?.receipt_data"
+        v-for="(receipt, receiptInfoKey) in receiptInfo?.receipt_data"
         :key="receiptInfoKey"
         class="mt-5 border-gray-400 pt-5 first:mt-0 [&:not(:first-child)]:border-t"
       >
@@ -16,6 +22,10 @@
         <p class="text-sm">
           <span class="font-bold">Hannah: </span>
           {{ formatPrice(receipt.person_2_amount) }}
+        </p>
+        <p class="text-sm">
+          <span class="font-bold">Date Posted: </span>
+          {{ formatDate(receipt.created_at) }}
         </p>
         <BaseButton
           :to="`/receipts/${receipt.receipt_id}`"
@@ -30,19 +40,41 @@
 <script setup lang="ts">
 import BaseButton from '@/components/atoms/BaseButton.vue'
 import PageTitle from '@/components/atoms/PageTitle.vue'
+import OrderSelectBox from '@/components/molecules/OrderSelectBox.vue'
+import { RECEIPT_ORDER } from '@/constants'
+import type {
+  ReceiptListInfoResponse,
+  ReceiptDisplayOrder
+} from '@/types/receipt'
 
 definePageMeta({
   layout: 'common-layout'
 })
-
+// consts
 const FIRST_PAGE = 1 as const
-
+// state
+const receiptInfo = ref<ReceiptListInfoResponse | null>()
 const currentPage = ref(FIRST_PAGE)
-const isLoading = ref(false)
+// TODO: 対応必須
+// const isLoading = ref(false)
+const sortOrder = ref<ReceiptDisplayOrder>(RECEIPT_ORDER.NEWEST)
+// composables
 const { getReceiptListData } = useGetReceiptList()
 const { data: receiptPaginationInfo } = await getReceiptListData(
-  currentPage.value
+  currentPage.value,
+  sortOrder.value
 )
+receiptInfo.value = receiptPaginationInfo
+// methods
+const orderChangedTodo = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
+  console.log('perry: orderChddangedTodo: valueTodo: ', receiptDisplayOrder)
+  const { data: receiptPaginationInfo } = await getReceiptListData(
+    currentPage.value,
+    receiptDisplayOrder
+  )
+  console.log('perry: receiptInfo.value: ', receiptInfo.value)
+  receiptInfo.value = receiptPaginationInfo
+}
 useHead({
   title: 'Receipt List'
 })

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -4,15 +4,15 @@
     <div>
       <OrderSelectBox
         :receipt-count="receiptInfo?.receipt_count || 0"
-        :min-count-todo="minCountTodo"
-        :max-count-todo="maxCountTodo"
+        :min-display-count="minDisplayCount"
+        :max-display-count="maxDisplayCount"
         class="mt-5"
-        @order-changed="orderChangedTodo"
+        @order-changed="changeListOrder"
       />
       <div v-if="isLoading" class="mt-5 flex items-center justify-center">
         <LoadingIcon />
       </div>
-      <template v-else>
+      <div v-else>
         <div
           v-for="(receipt, receiptInfoKey) in receiptInfo?.receipt_data"
           :key="receiptInfoKey"
@@ -33,13 +33,12 @@
           </p>
           <BaseButton
             :to="`/receipts/${receipt.receipt_id}`"
-            class="mt-4 px-5 py-2 first:mt-0"
+            class="mt-4 px-5 py-2"
           >
             見る
           </BaseButton>
         </div>
-      </template>
-      <!-- TODO: コンポーネント化する必要ある -->
+      </div>
       <div
         class="mt-5 flex items-center justify-between border-t border-gray-400 pt-4"
       >
@@ -115,20 +114,20 @@ const isOnFirstPage = computed(() => currentPage.value === FIRST_PAGE)
 const isOnLastPage = computed(
   () => currentPage.value === receiptInfo.value?.page_count
 )
-const minCountTodo = computed(
+const minDisplayCount = computed(
   () =>
     currentPage.value * MAX_RECEIPT_LIST_ITEMS_PER_PAGE -
     OFFSET_FOR_MIN_COUNT_TODO
 )
-const maxCountTodo = computed(() =>
+const maxDisplayCount = computed(() =>
   isOnLastPage.value
     ? receiptInfo.value?.receipt_count
     : currentPage.value * MAX_RECEIPT_LIST_ITEMS_PER_PAGE
 )
 // methods
-const orderChangedTodo = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
+const changeListOrder = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
   console.log(
-    'perry: orderChangedTodo: receiptDisplayOrder: ',
+    'perry: changeListOrder: receiptDisplayOrder: ',
     receiptDisplayOrder
   )
   const { data: receiptPaginationInfo } = await getReceiptListData(
@@ -138,11 +137,18 @@ const orderChangedTodo = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
   receiptInfo.value = receiptPaginationInfo
   sortOrder.value = receiptDisplayOrder
   currentPage.value = FIRST_PAGE
+  await navigateTo({
+    path: route.path,
+    query: {
+      ...route.query,
+      page: FIRST_PAGE
+    }
+  })
 }
 const changePage = async (clickedPageNumber: number) => {
   isLoading.value = true
   try {
-    // TODO: Double check how navigateTo works
+    // TODO: Double check how navigateTo works with navigation history
     await navigateTo({
       path: route.path,
       query: {
@@ -158,7 +164,7 @@ const changePage = async (clickedPageNumber: number) => {
     receiptInfo.value = receiptPaginationInfo
   } catch (error) {
     // TODO: エラーパターン追加必須
-    console.log('perry: error: ', error)
+    console.error(error)
   } finally {
     isLoading.value = false
   }

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -66,11 +66,10 @@ const { data: receiptPaginationInfo } = await getReceiptListData(
 )
 receiptInfo.value = receiptPaginationInfo
 // methods
-const orderChangedTodo = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
-  console.log('perry: orderChddangedTodo: valueTodo: ', receiptDisplayOrder)
+const orderChangedTodo = async (receiptDisplayOrder: string) => {
   const { data: receiptPaginationInfo } = await getReceiptListData(
     currentPage.value,
-    receiptDisplayOrder
+    receiptDisplayOrder as ReceiptDisplayOrder
   )
   console.log('perry: receiptInfo.value: ', receiptInfo.value)
   receiptInfo.value = receiptPaginationInfo

--- a/src/pages/receipts/index.vue
+++ b/src/pages/receipts/index.vue
@@ -89,7 +89,7 @@ const route = useRoute()
 // constants
 const FIRST_PAGE = 1 as const
 const MAX_RECEIPT_LIST_ITEMS_PER_PAGE = 10 as const
-const OFFSET_FOR_MIN_COUNT_TODO = 9
+const OFFSET_FOR_MIN_COUNT = 9
 // state
 const receiptInfo = ref<ReceiptListInfoResponse | null>()
 const currentPage = ref<number>(
@@ -116,8 +116,7 @@ const isOnLastPage = computed(
 )
 const minDisplayCount = computed(
   () =>
-    currentPage.value * MAX_RECEIPT_LIST_ITEMS_PER_PAGE -
-    OFFSET_FOR_MIN_COUNT_TODO
+    currentPage.value * MAX_RECEIPT_LIST_ITEMS_PER_PAGE - OFFSET_FOR_MIN_COUNT
 )
 const maxDisplayCount = computed(() =>
   isOnLastPage.value
@@ -126,10 +125,6 @@ const maxDisplayCount = computed(() =>
 )
 // methods
 const changeListOrder = async (receiptDisplayOrder: ReceiptDisplayOrder) => {
-  console.log(
-    'perry: changeListOrder: receiptDisplayOrder: ',
-    receiptDisplayOrder
-  )
   const { data: receiptPaginationInfo } = await getReceiptListData(
     FIRST_PAGE,
     receiptDisplayOrder as ReceiptDisplayOrder

--- a/src/pages/save-receipt/index.vue
+++ b/src/pages/save-receipt/index.vue
@@ -45,7 +45,7 @@ import type {
   MoveToStepThreePayload,
   MoveToStepTwoPayload,
   ReceiptInfo
-} from '@/interfaces/receipt'
+} from '@/types/receipt'
 import ReceiptOrganizer from '@/components/organisms/ReceiptOrganizer.vue'
 import ReceiptSavedSuccessfully from '@/components/organisms/ReceiptSavedSuccessfully.vue'
 

--- a/src/server/api/receipt-info.get.ts
+++ b/src/server/api/receipt-info.get.ts
@@ -1,12 +1,22 @@
-import { createError, defineEventHandler, setResponseStatus } from 'h3'
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  setResponseStatus
+} from 'h3'
 import { $fetch, FetchError } from 'ofetch'
 
 export default defineEventHandler(async (event) => {
+  const { pages, sort_by } = getQuery(event)
   try {
     const response = await $fetch(
       `${process.env.MEMORIES_BACKEND_URL}/api/receipt-info`,
       {
         method: 'GET',
+        params: {
+          pages,
+          sort_by
+        },
         headers: {
           Authorization: `Bearer ${process.env.BEARER_TOKEN}`
         }

--- a/src/server/api/receipt-info.get.ts
+++ b/src/server/api/receipt-info.get.ts
@@ -7,14 +7,14 @@ import {
 import { $fetch, FetchError } from 'ofetch'
 
 export default defineEventHandler(async (event) => {
-  const { pages, sort_by } = getQuery(event)
+  const { page, sort_by } = getQuery(event)
   try {
     const response = await $fetch(
       `${process.env.MEMORIES_BACKEND_URL}/api/receipt-info`,
       {
         method: 'GET',
         params: {
-          pages,
+          page,
           sort_by
         },
         headers: {

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -1,3 +1,5 @@
+import type { RECEIPT_ORDER } from '@/constants'
+
 export type SplitReceiptInfoResponse = {
   receipt_id: number
   title: string
@@ -60,3 +62,5 @@ export type ReceiptListInfoResponse = {
   receipt_data: SplitReceiptInfoResponse[]
   receipt_count: number
 }
+
+export type ReceiptOrder = (typeof RECEIPT_ORDER)[keyof typeof RECEIPT_ORDER]

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -61,6 +61,7 @@ export type MoveToStepThreePayload = {
 export type ReceiptListInfoResponse = {
   receipt_data: SplitReceiptInfoResponse[]
   receipt_count: number
+  page_count: number
 }
 
 export type ReceiptDisplayOrder =

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -63,4 +63,5 @@ export type ReceiptListInfoResponse = {
   receipt_count: number
 }
 
-export type ReceiptOrder = (typeof RECEIPT_ORDER)[keyof typeof RECEIPT_ORDER]
+export type ReceiptDisplayOrder =
+  (typeof RECEIPT_ORDER)[keyof typeof RECEIPT_ORDER]

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { formatDate } from './formatDate'
+
+describe('formatDate', () => {
+  it('should format ISO date string to YYYY/MM/DD format', () => {
+    const testCases = [
+      {
+        input: '2025-06-04T11:08:36.000000Z',
+        expected: '2025/6/4'
+      },
+      {
+        input: '2023-12-31T23:59:59.999Z',
+        // UTCから日本標準時の時間なので以下になる
+        expected: '2024/1/1'
+      },
+      {
+        input: '2022-01-01T00:00:00.000Z',
+        expected: '2022/1/1'
+      }
+    ]
+
+    testCases.forEach(({ input, expected }) => {
+      expect(formatDate(input)).toBe(expected)
+    })
+  })
+
+  it('should handle different time zones', () => {
+    const testCases = [
+      {
+        // Tokyo標準時
+        input: '2024-03-15T05:00:00+09:00',
+        expected: '2024/3/15'
+      },
+      {
+        // New York標準時
+        input: '2024-03-14T20:00:00-05:00',
+        expected: '2024/3/15'
+      }
+    ]
+
+    testCases.forEach(({ input, expected }) => {
+      expect(formatDate(input)).toBe(expected)
+    })
+  })
+
+  it('should throw an error for invalid date strings', () => {
+    const invalidCases = [
+      'not a date',
+      '',
+      // Invalid dateになるはずの日付
+      '2023-13-32'
+    ]
+    invalidCases.forEach((invalidInput) => {
+      expect(() => formatDate(invalidInput)).toThrow()
+    })
+  })
+})

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,13 @@
+export const formatDate = (dateString: string): string => {
+  const date = new Date(dateString)
+  if (!date.getTime()) {
+    throw new Error(`Invalid date string: ${dateString}`)
+  }
+  return date
+    .toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric'
+    })
+    .replace(/-/g, '/')
+}


### PR DESCRIPTION
## 概要

レシート一覧ページにPaginationと表示の並び順変更ナビゲーションを追加

## デザイン
Figmaリンク先: [参考](https://www.figma.com/design/5YJWfJxPOz41nTYUs3Ecsv/Split-Me-Up-Before-You-Go-Go?node-id=204-131&t=hqouiwrdsSXYDYYi-0)

<img width="930" height="989" alt="Image" src="https://github.com/user-attachments/assets/bcda6539-cfba-46f5-a60e-26347802c690" />

## キャプチャ



| BEFORE  | AFTER  |
|---|---|
| ![Before](https://github.com/user-attachments/assets/36352e54-a566-4921-ba38-ae02e4d3efb3)  |  ![movie](https://github.com/user-attachments/assets/a051241f-fd8e-4664-bab6-dd0570d9c1a2) |








Resolves https://github.com/PerryM123/split-my-receipt-up-frontend/issues/10